### PR TITLE
__FILE__并不一定总是返回绝对地址,当只返回单独一个文件名的时候,该函数"static char *_get_filename(co…

### DIFF
--- a/src/sdk-impl/qcloud_iot_sdk_impl.c
+++ b/src/sdk-impl/qcloud_iot_sdk_impl.c
@@ -41,7 +41,16 @@ LOG_LEVEL g_log_level = INFO;
 static char *_get_filename(const char *p)
 {
     char ch = '/';
-    char *q = strrchr(p,ch) + 1;
+    char *q = strrchr(p,ch);
+	if(q == NULL)
+	{
+		char temp[32] = {0};
+		q = strcpy(temp,p);
+	}
+	else
+	{
+		q++;
+	}
     return q;
 }
 


### PR DESCRIPTION
…nst char *p)"会返回一个NULL,进而导致Log_x系列函数触发一个SIGSEGV的错误